### PR TITLE
vendor kibana distro into habitat

### DIFF
--- a/.bldr.toml
+++ b/.bldr.toml
@@ -2,5 +2,7 @@
 plan_path = "filebeat"
 [journalbeat]
 plan_path = "journalbeat"
+[kibana]
+plan_path = "kibana"
 [metricbeat]
 plan_path = "metricbeat"

--- a/kibana/config/kibana.yml
+++ b/kibana/config/kibana.yml
@@ -1,0 +1,53 @@
+server.port: {{cfg.server.port}}
+server.host: {{cfg.server.host}}
+
+{{~#if cfg.server.basePath}}
+server.basePath: {{cfg.server.basePath}}
+{{~/if}}
+
+server.maxPayloadBytes: {{cfg.server.maxPayloadBytes}}
+
+{{~#if bind.elasticsearch}}
+# Kibana only takes on ES host in it's config
+elasticsearch.url: "http://{{bind.elasticsearch.members.[0].sys.ip}}:{{bind.elasticsearch.members.[0].cfg.http-port}}"
+{{else}}
+elasticsearch.url: {{cfg.elasticsearch.url}}:{{cfg.elasticsearch.port}}
+{{~/if}}
+
+elasticsearch.preserveHost: {{cfg.elasticsearch.preserveHost}}
+kibana.index: {{cfg.kibana.index}}
+kibana.defaultAppId: {{cfg.kibana.defaultAppId}}
+
+{{~#if cfg.elasticsearch.password }}
+elasticsearch.username: {{cfg.elasticsearch.username}}
+elasticsearch.password: {{cfg.elasticsearch.password}}
+{{~/if}}
+
+{{~#if cfg.server.ssl.key}}
+server.ssl.enabled: {{cfg.server.ssl.enabled}}
+server.ssl.certificate: {{cfg.server.ssl.certificate}}
+server.ssl.key: {{cfg.server.ssl.key}}
+{{~/if}}
+
+{{~#if cfg.elasticsearch.ssl.key}}
+elasticsearch.ssl.certificate: {{cfg.elasticsearch.ssl.certficate}}
+elasticsearch.ssl.key: {{cfg.elasticsearch.ssl.key}}
+{{~/if}}
+
+{{~#if cfg.elasticsearch.ssl.ca}}
+elasticsearch.ssl.ca: {{cfg.elasticsearch.ssl.ca}}
+{{~/if}}
+
+{{~#if cfg.elasticsearch.ssl.verificationMode}}
+elasticsearch.ssl.verificationMode: {{cfg.elasticsearch.ssl.verificationMode}}
+{{~/if}}
+
+elasticsearch.pingTimeout: {{cfg.elasticsearch.pingTimeout}}
+elasticsearch.requestTimeout: {{cfg.elasticsearch.requestTimeout}}
+elasticsearch.shardTimeout: {{cfg.elasticsearch.shardTimeout}}
+elasticsearch.startupTimeout: {{cfg.elasticsearch.startupTimeout}}
+pid.file: {{cfg.pid.file}}
+logging.dest: {{cfg.logging.dest}}
+logging.silent: {{cfg.logging.silent}}
+logging.quiet: {{cfg.logging.quiet}}
+logging.verbose: {{cfg.logging.verbose}}

--- a/kibana/default.toml
+++ b/kibana/default.toml
@@ -1,0 +1,88 @@
+[server]
+  # Kibana is served by a back end server. This controls which port to use.
+  port = "5601"
+
+  # The host to bind the server to.
+  host = "0.0.0.0"
+
+  # If you are running kibana behind a proxy, and want to mount it at a path,
+  # specify that path here. The basePath can't end in a slash.
+  basePath = ""
+
+  # The maximum payload size in bytes on incoming server requests.
+  maxPayloadBytes = 1048576
+
+    [server.ssl]
+    # SSL for outgoing requests from the Kibana Server to the browser (PEM formatted)
+    enabled = false
+    certificate = ""
+    key = ""
+
+[elasticsearch]
+  # The Elasticsearch instance to use for all your queries.
+  url = "http://localhost"
+  port = 9200
+  # preserve_elasticsearch_host true will send the hostname specified in `elasticsearch`. If you set it to false,
+  # then the host you use to connect to *this* Kibana instance will be sent.
+  preserveHost = true
+
+  # If your Elasticsearch is protected with basic auth, these are the user credentials
+  # used by the Kibana server to perform maintenance on the kibana_index at startup. Your Kibana
+  # users will still need to authenticate with Elasticsearch (which is proxied through
+  # the Kibana server)
+  username = ""
+  password = ""
+
+  # Time in milliseconds to wait for elasticsearch to respond to pings, defaults to
+  # request_timeout setting
+  pingTimeout = 1500
+
+  # Time in milliseconds to wait for responses from the back end or elasticsearch.
+  # This must be > 0
+  requestTimeout = 30000
+
+  # Time in milliseconds for Elasticsearch to wait for responses from shards.
+  # Set to 0 to disable.
+  shardTimeout = 0
+
+  # Time in milliseconds to wait for Elasticsearch at Kibana startup before retrying
+  startupTimeout = 5000
+
+    [elasticsearch.ssl]
+    # Optional setting to validate that your Elasticsearch backend uses the same key files (PEM formatted)
+    certficate = ""
+    key = ""
+
+    # If you need to provide a CA certificate for your Elasticsearch instance, put
+    # the path of the pem file here.
+    certificateAuthorities = [""]
+
+    # Set to false to have a complete disregard for the validity of the SSL
+    # certificate.
+    verificationMode = "full"
+
+[kibana]
+  # Kibana uses an index in Elasticsearch to store saved searches, visualizations
+  # and dashboards. It will create a new index if it doesn't already exist.
+  index = ".kibana"
+
+  # The default application to load.
+  defaultAppId = "discover"
+
+[pid]
+  # Set the path to where you would like the process id file to be created.
+  file = "/hab/svc/kibana/var/run/kibana.pid"
+
+[logging]
+  # If you would like to send the log output to a file you can set the path below.
+  dest = "stdout"
+
+  # Set this to true to suppress all logging output.
+  silent = false
+
+  # Set this to true to suppress all logging output except for error messages.
+  quiet = false
+
+  # Set this to true to log all events, including system usage information and all requests.
+  verbose = false
+

--- a/kibana/hooks/init
+++ b/kibana/hooks/init
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+exec 2>&1
+
+mkdir -p {{pkg.svc_static_path}}
+
+# Move directories that ship in the package into place
+# etc tasks ui_framework test -- are these important?
+# they aren't in the 6.5.4 distro...
+for dir in config node_modules package.json src bin webpackShims plugins do
+  rsync -a $(hab pkg path open-distro/kibana)/$dir {{pkg.svc_static_path}}/
+done
+
+mkdir -p {{pkg.svc_var_path}}/run

--- a/kibana/hooks/run
+++ b/kibana/hooks/run
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+exec 2>&1
+
+cd {{pkg.svc_path}}
+
+exec node {{pkg.svc_static_path}}/src/cli -c {{pkg.svc_config_path}}/kibana.yml

--- a/kibana/plan.sh
+++ b/kibana/plan.sh
@@ -1,0 +1,34 @@
+pkg_name=kibana
+pkg_version=6.5.4
+pkg_origin=open-distro
+pkg_license=('Apache-2.0')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="Kibana is a browser based analytics and search dashboard for Elasticsearch."
+pkg_upstream_url="https://www.elastic.co/products/kibana"
+pkg_source="https://artifacts.elastic.co/downloads/${pkg_name}/${pkg_name}-oss-${pkg_version}-linux-x86_64.tar.gz"
+pkg_shasum=9730cb8420704716ba91540530f9ea9238d91b9044eaf7e7107aa35fc5fc0684
+pkg_deps=(core/node8/8.14.0 core/rsync) # Kibana is only supported if it runs on the version of node that ships with the release
+pkg_exports=(
+  [port]=server.port
+)
+pkg_exposes=(port)
+pkg_binds_optional=(
+  [elasticsearch]="http-port"
+)
+pkg_bin_dirs=(bin)
+
+do_build () {
+  return 0
+}
+
+do_install() {
+  cp -r "${HAB_CACHE_SRC_PATH}/${pkg_name}-${pkg_version}-linux-x86_64/"* "${pkg_prefix}/"
+  # Delete the /config directory created by Kibana installer; habitat lays down
+  # /config/kibana.yml
+rm -rv "${pkg_prefix}/config/"
+}
+
+do_strip() {
+  return 0
+}
+


### PR DESCRIPTION
Signed-off-by: echohack <echohack@users.noreply.github.com>

This almost feels like cheating, and I'm not 100% sure if this is going to be the right way going forward, but this should work, at least for now.

One concern is that the distribution for 6.5.4 is missing some directories that were present in 6.1.x. I'm not entirely sure if these are strickly required, as the service seemed to run without errors for me.

These folders are : ```etc tasks ui_framework test```